### PR TITLE
Add TMC2209 driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "drivers/a4988",
     "drivers/drv8825",
     "drivers/stspin220",
+    "drivers/tmc2209",
 ]
 default-members = [
     ".",
@@ -11,6 +12,7 @@ default-members = [
     "drivers/a4988",
     "drivers/drv8825",
     "drivers/stspin220",
+    "drivers/tmc2209",
 ]
 
 [package]
@@ -56,8 +58,9 @@ typenum = "1.12.0"
 
 
 [features]
-default = ["a4988", "drv8825", "stspin220", "dq542ma"]
+default = ["a4988", "drv8825", "stspin220", "dq542ma", "tmc2209"]
 a4988 = []
 drv8825 = []
 stspin220 = []
 dq542ma = []
+tmc2209 = []

--- a/drivers.toml
+++ b/drivers.toml
@@ -14,3 +14,9 @@ pololu_url = "https://www.pololu.com/category/154/"
 name = "stspin220"
 product_url = "https://www.st.com/en/motor-drivers/stspin220.html"
 pololu_url = "https://www.pololu.com/category/260/"
+
+[[drivers]]
+name = "tmc2209"
+product_url = "https://www.analog.com/en/products/tmc2209.html"
+pololu_url = ""
+

--- a/drivers/tmc2209/Cargo.toml
+++ b/drivers/tmc2209/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name    = "tmc2209"
+version = "0.6.0"
+authors = [
+    "Hanno Braun <hanno@braun-embedded.com>",
+    "Nicholas Sica <njs82@drexel.edu>",
+]
+edition = "2018"
+
+description = "Driver crate for the TMC2209 stepper motor driver"
+repository  = "https://github.com/braun-embedded/stepper"
+license     = "0BSD"
+keywords    = ["stepper", "motor", "driver", "pololu"]
+categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
+
+
+[dependencies.stepper]
+version          = "0.6.0"
+path             = "../.."
+default-features = false
+features         = ["tmc2209"]

--- a/drivers/tmc2209/README.md
+++ b/drivers/tmc2209/README.md
@@ -1,0 +1,21 @@
+# DRV8825 Driver [![crates.io](https://img.shields.io/crates/v/drv8825.svg)](https://crates.io/crates/drv8825) [![Documentation](https://docs.rs/drv8825/badge.svg)](https://docs.rs/drv8825) ![CI Build](workflows/CI%20Build/badge.svg)
+
+## About
+
+Rust driver crate for the [DRV8825] stepper motor driver. Carrier boards for this chip are [available from Pololu].
+
+This crate is a specialized facade for the [Stepper] library. Please consider using Stepper directly, as it provides drivers for more stepper motor drivers, as well as an interface to abstract over them.
+
+See [Stepper] for more documentation and usage examples.
+
+## License
+
+This project is open source software, licensed under the terms of the [Zero Clause BSD License] (0BSD, for short). This basically means you can do anything with the software, without any restrictions, but you can't hold the authors liable for problems.
+
+See [LICENSE.md] for full details.
+
+[drv8825]: https://www.ti.com/product/DRV8825
+[available from pololu]: https://www.pololu.com/category/154/
+[Stepper]: https://crates.io/crates/stepper
+[zero clause bsd license]: https://opensource.org/licenses/0BSD
+[license.md]: LICENSE.md

--- a/drivers/tmc2209/src/lib.rs
+++ b/drivers/tmc2209/src/lib.rs
@@ -1,0 +1,15 @@
+//! DRV8825 Driver
+//!
+//! Platform-agnostic driver library for the DRV8825 stepper motor driver.
+//! This crate is a specialized facade for the [Stepper] library. Please
+//! consider using Stepper directly, as it provides drivers for more stepper
+//! motor drivers, as well as an interface to abstract over them.
+//!
+//! See [Stepper] for more documentation and usage examples.
+//!
+//! [Stepper]: https://crates.io/crates/stepper
+
+#![no_std]
+#![deny(missing_docs)]
+
+pub use stepper::{drivers::tmc2209::*, *};

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -15,3 +15,7 @@ pub mod stspin220;
 
 #[cfg(feature = "dq542ma")]
 pub mod dq542ma;
+
+#[cfg(feature = "tmc2209")]
+pub mod tmc2209;
+

--- a/src/drivers/tmc2209.rs
+++ b/src/drivers/tmc2209.rs
@@ -1,0 +1,211 @@
+//! TMC2099 Driver
+//!
+//! This can have a UART controller to control a lot of the functionality
+//! through software, but it still needs to be implemented
+//!
+//! Platform-agnostic driver API for the TMC2099 stepper motor driver. Can be
+//! used on any platform for which implementations of the required
+//! [embedded-hal] traits are available.
+//!
+//! For the most part, users are not expected to use this API directly. Please
+//! check out [`Stepper`](crate::Stepper) instead.
+//!
+//! [embedded-hal]: https://crates.io/crates/embedded-hal
+
+use core::convert::Infallible;
+
+use embedded_hal::digital::{OutputPin, PinState};
+use fugit::NanosDurationU32 as Nanoseconds;
+
+use crate::{
+    step_mode::StepMode64,
+    traits::{
+        EnableDirectionControl, EnableStepControl, EnableStepModeControl,
+        SetDirection, SetStepMode, Step as StepTrait,
+    },
+};
+
+/// The TMC2099 driver API
+///
+/// Users are not expected to use this API directly, except to create an
+/// instance using [`TMC2099::new`]. Please check out
+/// [`Stepper`](crate::Stepper) instead.
+// Pins left out- SPREAD, CLK- tie to gnd for internal supply, PDN_UART, VREF
+// For UART Config use address 0..3 instead of MS pins
+pub struct TMC2099<ENN, STDBY, DIAG, MS1_AD0, MS2_AD1, STEP, DIR> {
+    enable_n: ENN,
+    standby: STDBY,
+    diagnostic: DIAG,
+    mode0: MS1_AD0,
+    mode1: MS2_AD1,
+    step: STEP,
+    dir: DIR,
+}
+
+impl TMC2099<(), (), (), (), (), (), ()> {
+    /// Create a new instance of `TMC2099`
+    pub fn new() -> Self {
+        Self {
+            enable_n: (),
+            standby: (),
+            diagnostic: (),
+            mode0: (),
+            mode1: (),
+            step: (),
+            dir: (),
+        }
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError>
+    EnableStepModeControl<(ENN, STDBY, MS1_AD0, MS2_AD1)>
+    for TMC2099<(), (), (), (), (), Step, Dir>
+where
+    ENN: OutputPin<Error = OutputPinError>,
+    STDBY: OutputPin<Error = OutputPinError>,
+    MS1_AD0: OutputPin<Error = OutputPinError>,
+    MS2_AD1: OutputPin<Error = OutputPinError>,
+{
+    type WithStepModeControl =
+        TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>;
+
+    fn enable_step_mode_control(
+        self,
+        (enable_n, standby, mode0, mode1): (ENN, STDBY, MS1_AD0, MS2_AD1),
+    ) -> Self::WithStepModeControl {
+        TMC2099 {
+            enable_n,
+            standby,
+            diagnostic: self.diagnostic,
+            mode0,
+            mode1,
+            step: self.step,
+            dir: self.dir,
+        }
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError> SetStepMode
+    for TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>
+where
+    ENN: OutputPin<Error = OutputPinError>,
+    STDBY: OutputPin<Error = OutputPinError>,
+    MS1_AD0: OutputPin<Error = OutputPinError>,
+    MS2_AD1: OutputPin<Error = OutputPinError>,
+{
+    // Timing Requirements (page 6)
+    // https://www.pololu.com/file/0J450/A4988.pdf
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(20);
+    const HOLD_TIME: Nanoseconds = Nanoseconds::from_ticks(20);
+
+    type Error = OutputPinError;
+    type StepMode = StepMode64;
+
+    fn apply_mode_config(
+        &mut self,
+        step_mode: Self::StepMode,
+    ) -> Result<(), Self::Error> {
+        // Reset the device's internal logic and disable the h-bridge drivers.
+        self.enable_n.set_high()?;
+        self.standby.set_high()?;
+
+        use PinState::*;
+        use StepMode64::*;
+        let (mode0, mode1) = match step_mode {
+            M8 => (Low, Low),
+            M32 => (Low, High),
+            M64 => (High, Low),
+            M16 => (High, High),
+            _ => (High, Low),
+        };
+
+        // Set mode signals.
+        self.mode0.set_state(mode0)?;
+        self.mode1.set_state(mode1)?;
+
+        Ok(())
+    }
+
+    fn enable_driver(&mut self) -> Result<(), Self::Error> {
+        self.enable_n.set_low()?;
+        self.standby.set_low()
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError>
+    EnableDirectionControl<Dir>
+    for TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, ()>
+where
+    Dir: OutputPin<Error = OutputPinError>,
+{
+    type WithDirectionControl =
+        TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>;
+
+    fn enable_direction_control(self, dir: Dir) -> Self::WithDirectionControl {
+        TMC2099 {
+            enable_n: self.enable_n,
+            standby: self.standby,
+            diagnostic: self.diagnostic,
+            mode0: self.mode0,
+            mode1: self.mode1,
+            step: self.step,
+            dir,
+        }
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError> SetDirection
+    for TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>
+where
+    Dir: OutputPin<Error = OutputPinError>,
+{
+    // Timing Requirements (page 6)
+    // https://www.pololu.com/file/0J450/A4988.pdf
+    const SETUP_TIME: Nanoseconds = Nanoseconds::from_ticks(20);
+
+    type Dir = Dir;
+    type Error = Infallible;
+
+    fn dir(&mut self) -> Result<&mut Self::Dir, Self::Error> {
+        Ok(&mut self.dir)
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError>
+    EnableStepControl<Step>
+    for TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>
+where
+    Step: OutputPin<Error = OutputPinError>,
+{
+    type WithStepControl = TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>;
+
+    fn enable_step_control(self, step: Step) -> Self::WithStepControl {
+        TMC2099 {
+            enable_n: self.enable_n,
+            standby: self.standby,
+            diagnostic: self.diagnostic,
+            mode0: self.mode0,
+            mode1: self.mode1,
+            step,
+            dir: self.dir,
+        }
+    }
+}
+
+impl<ENN, STDBY, MS1_AD0, MS2_AD1, Step, Dir, OutputPinError> StepTrait
+    for TMC2099<ENN, STDBY, (), MS1_AD0, MS2_AD1, Step, Dir>
+where
+    Step: OutputPin<Error = OutputPinError>,
+{
+    // Timing Requirements (page 63)
+    // TODO: Add URL
+    // min of max(filtering_time, fclk+20)- went with typical val
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds::from_ticks(100);
+
+    type Step = Step;
+    type Error = Infallible;
+
+    fn step(&mut self) -> Result<&mut Self::Step, Self::Error> {
+        Ok(&mut self.step)
+    }
+}


### PR DESCRIPTION
I saw the discussion on the TMC2209(a driver I now need) and it seems like it was never implemented. I saw the other crate, but it seemed outdated. I haven't tested this at all, but I thought I'd open this pull request in case anyone thinks to in the meantime.

This implements the very basic controls with no UART control of the driver, which should probably be the next step after testing the initial driver.